### PR TITLE
Fix kotlin type mismatch error

### DIFF
--- a/app/src/main/java/com/lionido/simplewidget/widget/DayCounterWidget.kt
+++ b/app/src/main/java/com/lionido/simplewidget/widget/DayCounterWidget.kt
@@ -120,7 +120,7 @@ fun DayCounterWidgetContent(widget: WidgetData) {
             )
             
             if (widget.startDate != null) {
-                val days: String = calculateDaysFromString(widget.startDate, widget.startFromZero)
+                val days: String = calculateDaysFromTimestamp(widget.startDate, widget.startFromZero)
                 Text(
                     text = days,
                     style = TextStyle(
@@ -141,9 +141,9 @@ fun DayCounterWidgetContent(widget: WidgetData) {
     }
 }
 
-private fun calculateDaysFromString(startDate: String, startFromZero: Boolean): String {
+private fun calculateDaysFromTimestamp(startDate: Long, startFromZero: Boolean): String {
     return try {
-        val start = LocalDate.parse(startDate)
+        val start = LocalDate.ofEpochDay(startDate)
         val today = LocalDate.now()
         val days = ChronoUnit.DAYS.between(start, today)
         val result = if (startFromZero) days else days + 1


### PR DESCRIPTION
Refactor date calculation function to accept `Long` timestamp instead of `String` to fix a type mismatch error.

---
<a href="https://cursor.com/background-agent?bcId=bc-228f41b0-c709-4ed4-bb29-d270065d08cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-228f41b0-c709-4ed4-bb29-d270065d08cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

